### PR TITLE
Logger can be overridden from external sources

### DIFF
--- a/restgate.go
+++ b/restgate.go
@@ -20,7 +20,6 @@ import (
 	"crypto/subtle"
 	"database/sql"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -61,21 +60,7 @@ type RESTGate struct {
 }
 
 type ALogger interface {
-	Fatal(v ...interface{})
-	Fatalf(format string, v ...interface{})
-	Fatalln(v ...interface{})
-	Flags() int
-	Output(calldepth int, s string) error
-	Panic(v ...interface{})
-	Panicf(format string, v ...interface{})
-	Panicln(v ...interface{})
-	Prefix() string
-	Print(v ...interface{})
 	Printf(format string, v ...interface{})
-	Println(v ...interface{})
-	SetFlags(flag int)
-	SetOutput(w io.Writer)
-	SetPrefix(prefix string)
 }
 
 func New(headerKeyLabel string, headerSecretLabel string, as AuthenticationSource, config Config) *RESTGate {

--- a/restgate.go
+++ b/restgate.go
@@ -65,7 +65,7 @@ type ALogger interface {
 
 func New(headerKeyLabel string, headerSecretLabel string, as AuthenticationSource, config Config) *RESTGate {
 	if config.Logger == nil {
-		config.Logger = log.New(os.Stdout, "", 0)
+		config.Logger = log.New(os.Stderr, "", LstdFlags)
 	}
 	t := &RESTGate{headerKeyLabel: headerKeyLabel, headerSecretLabel: headerSecretLabel, source: as, config: config}
 	t.config.Logger.Printf("RestGate initializing")


### PR DESCRIPTION
Adds a log interface so the log can be integrated with external sources  (Like negroni's logger or a logstash logger)

```golang
  logger := negroni.NewLogger()
  n := negroni.New(negroni.NewRecovery(), logger, negroni.NewStatic(http.Dir("public")))
  n.Use(restgate.New("X-Auth-Key", "X-Auth-Secret", restgate.Static, restgate.Config{Key: []string{"test"}, Secret: []string{"abcdefg"}, Logger:logger}))
```